### PR TITLE
Add home interface with read: all attribute

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,9 +39,9 @@ plugs:
     interface: content
     content: npu-libs-2404
     target: $SNAP/npu-libs
-  # To allow sideloading models by root
-  # home:
-  #   read: all
+  # To allow sideloading models by root daemon
+  home:
+    read: all
     
 hooks:
   install:


### PR DESCRIPTION
Enable home access for sideloading models by root daemon.

Depends on https://forum.snapcraft.io/t/auto-connection-of-hardware-observe-and-home-for-gemma3/49246/2