### PR TITLE
Mark intel engines as devel due to chat client issues

### DIFF
--- a/engines/intel-cpu/engine.yaml
+++ b/engines/intel-cpu/engine.yaml
@@ -1,7 +1,7 @@
 name: intel-cpu
 description: Use Intel CPUs
 vendor: Intel Corporation
-grade: stable
+grade: devel
 devices:
   allof:
     - type: cpu

--- a/engines/intel-gpu/engine.yaml
+++ b/engines/intel-gpu/engine.yaml
@@ -1,7 +1,7 @@
 name: intel-gpu
 description: Use Intel integrated and discrete GPUs
 vendor: Intel Corporation
-grade: stable
+grade: devel
 devices:
   allof:
     - type: cpu


### PR DESCRIPTION
There are some issues with the intel-cpu and intel-gpu engines, namely the chat issue mentioned [here](https://github.com/canonical/gemma3-snap/pull/8#issuecomment-3517409670). The issue is being worked on at https://github.com/jpm-canonical/go-chat-client/pull/13

Moreover, the model used for these engines isn't optimized by Intel. The optimizations are work in progress.