### PR TITLE
Use PPA for intel GPU dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,12 @@ hooks:
       - kernel-module-observe
       - opengl
 
+package-repositories:
+  - type: apt
+    ppa: kobuk-team/intel-graphics
+    priority: prefer
+    key-id: 0C0E6AF955CE463C03FC51574D098D70AFBE5E1F
+
 parts:
   version:
     plugin: dump
@@ -136,41 +142,35 @@ parts:
       # Exclude everything not explicitly organized
       - -*
   
-  opencl-driver:
-    # Includes the OpenCL runtime for Intel GPU support
+  # From https://github.com/snapcrafters/obs-studio/blob/b630ad6e8eb0f4ecf517c887ecf3e8fc57ca64f7/snap/snapcraft.yaml#L53-L80
+  # TODO: Verify which packages are actually needed
+  intel-graphics:
     plugin: nil
-    build-packages:
-      - wget
-    override-build: |
-      # Only install intel opencl drivers on amd64
-      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]; then
-        # Legacy Intel OpenCL Runtime
-        mkdir -p $CRAFT_PART_BUILD/opencl-intel-legacy1
-        cd $CRAFT_PART_BUILD/opencl-intel-legacy1
-        wget -q https://github.com/intel/compute-runtime/releases/download/24.35.30872.36/intel-level-zero-gpu-legacy1_1.5.30872.36_amd64.deb
-        wget -q https://github.com/intel/compute-runtime/releases/download/24.35.30872.36/intel-opencl-icd-legacy1_24.35.30872.36_amd64.deb
-        dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
-      
-        # Recent Intel OpenCL Runtime
-        mkdir -p $CRAFT_PART_BUILD/opencl-intel
-        cd $CRAFT_PART_BUILD/opencl-intel
-        wget -q https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-core-2_2.5.6+18417_amd64.deb
-        wget -q https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-opencl-2_2.5.6+18417_amd64.deb
-        wget -q https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-level-zero-gpu_1.6.32224.5_amd64.deb
-        wget -q https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-opencl-icd_24.52.32224.5_amd64.deb
-        wget -q https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/libigdgmm12_22.5.5_amd64.deb
-        dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
-      
-        # Two symlinks are created by installing opencl: 
-        # etc/alternatives/ocloc -> /usr/bin/ocloc-24.52.1, usr/bin/ocloc -> /etc/alternatives/ocloc
-        # These point to outside of the snap and fails store review. They are not required, so remove it.
-        rm $CRAFT_PART_INSTALL/etc/alternatives/ocloc
-        rm $CRAFT_PART_INSTALL/usr/bin/ocloc
-      
-        cd $CRAFT_PART_BUILD
-      fi # End of intel-opencl driver installation
-      
-      craftctl default
+    stage-packages:
+      - intel-media-va-driver-non-free
+      - intel-metrics-discovery
+      - intel-ocloc
+      - intel-opencl-icd
+      - libigc2
+      - libigc-tools
+      - libigdfcl2
+      - libigdgmm12
+      - libmfx1
+      - libmfx-gen1
+      - libva-drm2
+      - libva-glx2
+      - libva-wayland2
+      - libva-x11-2
+      - libvpl2
+      - libze1
+      - libze-intel-gpu1
+      - ocl-icd-libopencl1
+      # Note, these -dev packages deliver development sym links that
+      # may be dynamically loaded by Intel compute runtime drivers.
+      - libigc-dev
+      - libigdfcl-dev
+    prime:
+      - -usr/include
 
   llamacpp:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,28 +147,29 @@ parts:
   intel-graphics:
     plugin: nil
     stage-packages:
-      - intel-media-va-driver-non-free
-      - intel-metrics-discovery
-      - intel-ocloc
-      - intel-opencl-icd
-      - libigc2
-      - libigc-tools
-      - libigdfcl2
-      - libigdgmm12
-      - libmfx1
-      - libmfx-gen1
-      - libva-drm2
-      - libva-glx2
-      - libva-wayland2
-      - libva-x11-2
-      - libvpl2
-      - libze1
-      - libze-intel-gpu1
-      - ocl-icd-libopencl1
-      # Note, these -dev packages deliver development sym links that
-      # may be dynamically loaded by Intel compute runtime drivers.
-      - libigc-dev
-      - libigdfcl-dev
+      - on amd64:
+        - intel-media-va-driver-non-free
+        - intel-metrics-discovery
+        - intel-ocloc
+        - intel-opencl-icd
+        - libigc2
+        - libigc-tools
+        - libigdfcl2
+        - libigdgmm12
+        - libmfx1
+        - libmfx-gen1
+        - libva-drm2
+        - libva-glx2
+        - libva-wayland2
+        - libva-x11-2
+        - libvpl2
+        - libze1
+        - libze-intel-gpu1
+        - ocl-icd-libopencl1
+        # Note, these -dev packages deliver development sym links that
+        # may be dynamically loaded by Intel compute runtime drivers.
+        - libigc-dev
+        - libigdfcl-dev
     prime:
       - -usr/include
 


### PR DESCRIPTION
The version [24.52.32224.5](https://github.com/intel/compute-runtime/releases/tag/24.52.32224.5) of packages do not support Panther Lake iGPUs. The production support for PTL seems to land in [26.01.36711.4](https://github.com/intel/compute-runtime/releases/tag/26.01.36711.4).

The [kobuk-team/intel-graphics](https://blueprints.launchpad.net/~kobuk-team/+archive/ubuntu/intel-graphics) PPA includes [25.48.36300](https://github.com/intel/compute-runtime/releases/tag/25.48.36300.8) which has pre-release support for Panther Lake. This PR switches to this PPA to bundle a pre-validated and compatible set of dependencies.

