### PR TITLE
Update CLI to v1.0.0-beta.29

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,7 +89,7 @@ parts:
 
   cli:
     source: https://github.com/canonical/inference-snaps-cli.git
-    source-tag: v1.0.0-beta.28
+    source-tag: v1.0.0-beta.29
     plugin: go
     build-snaps:
       - go/1.24/stable


### PR DESCRIPTION
CLI changes:
- https://github.com/canonical/inference-snaps-cli/releases/tag/v1.0.0-beta.29