### PR TITLE
Remove wsl workaround

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -111,13 +111,22 @@ parts:
     plugin: nil
     stage-packages:
       - pciutils # lspci
-      - nvidia-utils-580 # nvidia-smi, used for NVIDIA vRAM and CUDA Capability detection
       - clinfo # used for Intel GPU vRAM detection. It depends on intel-opencl-icd
-    prime:
-      # Exclude nvidia icd to avoid clinfo from looking up properties for nvidia GPUs.
-      # See: https://github.com/canonical/inference-snaps/issues/148
-      - -etc/OpenCL/vendors/nvidia.icd
-    
+
+  # Used for NVIDIA vRAM and CUDA Capability detection.
+  # Only the binary is included to avoid staging libraries, which should instead be provided by the host through the opengl interface.
+  nvidia-smi:
+    plugin: nil
+    build-packages:
+      - nvidia-utils-580
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/usr/bin/
+      
+      license_dir=$CRAFT_PART_INSTALL/usr/share/doc/nvidia-utils-580/
+      mkdir -p $license_dir
+      cp /usr/share/doc/nvidia-utils-580/copyright $license_dir/
+
   # OpenCL ICD and libigdgmm are required for Intel GPU vRAM lookup with clinfo
   intel-opencl-icd:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,9 +43,6 @@ layout:
   # Intel icd files use an absolute path to Intel OpenCL shared objects. Use a layout to mount the so files at the expected location
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/intel-opencl:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/intel-opencl
-  # Under wsl the libraries are expected in /usr/lib/wsl. This is required in addition to setting LD_LIBRARY_PATH.
-  /usr/lib/wsl:
-    bind: $SNAP_COMMON/wsl
 
 plugs:
   intel-npu:


### PR DESCRIPTION
DO NOT MERGE

The wsl workaround we added prevents a proper fix from providing the libraries at the correct path, as the layout will be mounted on top of it and hide them.

See proper fix: https://github.com/canonical/snapd/pull/16726

This PR removes the workaround. This should be merged after the fix has been applied and rolled out in snapd.