### PR TITLE
Add config for sideloading models to amd-gpu engine

### DIFF
--- a/components/llamacpp-rocm/server
+++ b/components/llamacpp-rocm/server
@@ -10,9 +10,16 @@ if [ "${verbose}" = "true" ]; then
   EXTRA_ARGS+=(--verbose)
 fi
 
+model=$MODEL_FILE
+sideloaded_model="$(modelctl get sideloaded.model)"
+if [[ -n "$sideloaded_model" && "$sideloaded_model" != "false" ]]; then
+    echo "Using sideloaded model: $model"
+    model="$sideloaded_model"
+fi
+
 set -x
 exec llama-server \
-  --model "$MODEL_FILE" \
+  --model "$model" \
   --port "$port" \
   --host "$host" \
   --no-warmup \

--- a/engines/amd-gpu/engine.yaml
+++ b/engines/amd-gpu/engine.yaml
@@ -60,3 +60,5 @@ components:
   - mmproj-f16-4b-gguf
 configurations:
   sleep-idle-seconds: 600
+  sideloaded.model: false
+  sideloaded.mmproj: false

--- a/engines/amd-gpu/server
+++ b/engines/amd-gpu/server
@@ -2,4 +2,13 @@
 
 sleep_idle_seconds="$(modelctl get sleep-idle-seconds)"
 
-exec "$SNAP_COMPONENTS/llamacpp-rocm/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds"
+mmproj=$MMPROJ_FILE
+sideloaded_mmproj="$(modelctl get sideloaded.mmproj)"
+
+if [[ -n "$sideloaded_mmproj" && "$sideloaded_mmproj" != "false" ]]; then
+    echo "Using sideloaded mmproj: $mmproj"
+    mmproj="$sideloaded_mmproj"
+fi
+
+exec "$SNAP_COMPONENTS/llamacpp-rocm/server" --mmproj "$mmproj" --sleep-idle-seconds "$sleep_idle_seconds"
+


### PR DESCRIPTION
This should not be merged. It is a hack to allow using models other than 4b with the amd-gpu engine.

Usage instructions:
```
sudo snap install gemma3 --channel=edge/pr-94
sudo snap connect gemma3:process-control
sudo snap connect gemma3:home # if loading model from user's home
sudo gemma3 use-engine amd-gpu

MODEL_DIR=$HOME/models
cd $MODEL_DIR
wget https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-gguf/resolve/main/gemma-3-12b-it-q4_0.gguf
wget https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-gguf/resolve/main/mmproj-model-f16-12B.gguf

sudo gemma3 set sideloaded.model=$MODEL_DIR/gemma-3-12b-it-q4_0.gguf
sudo gemma3 set sideloaded.mmproj=$MODEL_DIR/mmproj-model-f16-12B.gguf

sudo snap restart gemma3
```

For the 27b model, download from https://huggingface.co/google/gemma-3-27b-it-qat-q4_0-gguf/tree/main and use in a similar way.