### PR TITLE
Take engine name from status

### DIFF
--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -5,5 +5,5 @@
 mkdir -p "$STATUS_SHARE"
 modelctl status --wait-for-components --format=json > "$STATUS_SHARE/status.json"
 
-engine="$(modelctl show-engine --format=json | jq -r .name)"
-modelctl run "$SNAP/engines/$engine/server" --wait-for-components
+engine="$(modelctl status --format=json | jq -r .engine)"
+exec modelctl run "$SNAP/engines/$engine/server" --wait-for-components

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -1,9 +1,11 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -euo pipefail
 
 # Save the status for content sharing
 # This must be done each time the server is started to expose the actual status
 mkdir -p "$STATUS_SHARE"
 modelctl status --wait-for-components --format=json > "$STATUS_SHARE/status.json"
 
-engine="$(modelctl status --format=json | jq -r .engine)"
+engine="$(modelctl status --wait-for-components --format=json | jq -r .engine)"
 exec modelctl run "$SNAP/engines/$engine/server" --wait-for-components


### PR DESCRIPTION
This is better than taking the engine name from `show-engine` because `status` does not involve scoring.