### PR TITLE
Drop engine-specific webui from endpoints

### DIFF
--- a/components/llamacpp-cuda/component.yaml
+++ b/components/llamacpp-cuda/component.yaml
@@ -2,9 +2,6 @@ servers:
   openai:
     protocol: http
     base-path: /v1
-  webui:
-    protocol: http
-    base-path: /
 
 environment:
 # Add llama.cpp binaries

--- a/components/llamacpp-rocm/component.yaml
+++ b/components/llamacpp-rocm/component.yaml
@@ -2,9 +2,6 @@ servers:
   openai:
     protocol: http
     base-path: /v1
-  webui:
-    protocol: http
-    base-path: /
 
 environment:
 # Add llama.cpp binaries

--- a/components/llamacpp/component.yaml
+++ b/components/llamacpp/component.yaml
@@ -2,9 +2,6 @@ servers:
   openai:
     protocol: http
     base-path: /v1
-  webui:
-    protocol: http
-    base-path: /
 
 environment:
 # Add llama.cpp binaries


### PR DESCRIPTION
The `webui` endpoint entry will be used to list the snap's built-in web ui.