### PR TITLE
Promote amd-gpu engine to stable

### DIFF
--- a/engines/amd-gpu/engine.yaml
+++ b/engines/amd-gpu/engine.yaml
@@ -1,7 +1,7 @@
 name: amd-gpu
 description: "Use ROCm for inference on AMD GPUs."
 vendor: Canonical Ltd
-grade: devel
+grade: stable
 devices:
   allof:
     - type: cpu


### PR DESCRIPTION
Promoting `amd-gpu` engine from devel to stable after being granted `process-control` [autoconnection](https://forum.snapcraft.io/t/autoconnect-request-process-control-for-gemma3-snap/50971)