### PR TITLE
Bump to CLI v1.0.0-beta.41 and use the new serve-webui command

### DIFF
--- a/scripts/server-webui.sh
+++ b/scripts/server-webui.sh
@@ -15,4 +15,4 @@ else
     capabilities="text, vision"
 fi
 
-exec modelctl serve-ui "$SNAP/webui" --port "$port" --host "$host" --capabilities "$capabilities"
+exec modelctl serve-webui "$SNAP/webui" --port "$port" --host "$host" --capabilities "$capabilities"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -104,8 +104,8 @@ parts:
 
   cli:
     source:
-      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v1.0.0-beta.40/inference-snaps-cli-linux-amd64.tar.xz
-      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v1.0.0-beta.40/inference-snaps-cli-linux-arm64.tar.xz
+      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v1.0.0-beta.41/inference-snaps-cli-linux-amd64.tar.xz
+      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v1.0.0-beta.41/inference-snaps-cli-linux-arm64.tar.xz
     plugin: dump
     override-build: |
       mkdir -p bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -164,7 +164,7 @@ parts:
 
   webui:
     plugin: dump
-    source: https://github.com/canonical/inference-snaps-ui.git
+    source: https://github.com/canonical/inference-snaps-webui.git
     source-tag: v1.0.0-beta.2
     organize:
       "static": webui/


### PR DESCRIPTION
- Bump canonical/inference-snaps-cli to [v1.0.0-beta.41](https://github.com/canonical/inference-snaps-cli/releases/tag/v1.0.0-beta.41), which changes the webui server command from serve-ui to -serve-webui
- Replace serve-ui with serve-webui command
- Update webui repo URL

I've tested a local build.