### PR TITLE
Update renovate and source URLs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,11 +24,11 @@
         "^snap/snapcraft\\.yaml$"
       ],
       "matchStrings": [
-        "https://github\\.com/jpm-canonical/llama\\.cpp-builds/releases/download/(?<currentValue>[^/]+)/llamacpp",
+        "https://github\\.com/canonical/llama\\.cpp-builds/releases/download/(?<currentValue>[^/]+)/llamacpp",
         "(?ms)^\\s*llamacpp[^:]*:\\s*$\\n(?:^\\s+.*$\\n)*?^\\s*version:\\s*(?<currentValue>b\\d+)\\s*$"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "jpm-canonical/llama.cpp-builds",
+      "depNameTemplate": "canonical/llama.cpp-builds",
       "versioningTemplate": "regex:^b(?<major>\\d+)$"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,8 @@
     {
       "customType": "regex",
       "description": "Update inference-snaps-cli",
-      "fileMatch": [
-        "^snap/snapcraft\\.yaml$"
+      "managerFilePatterns": [
+        "snap/snapcraft.yaml"
       ],
       "matchStrings": [
         "https://github\\.com/canonical/inference-snaps-cli/releases/download/(?<currentValue>v[^/]+)/inference-snaps-cli"
@@ -20,8 +20,8 @@
     {
       "customType": "regex",
       "description": "Update inference-snaps-webui",
-      "fileMatch": [
-        "^snap/snapcraft\\.yaml$"
+      "managerFilePatterns": [
+        "snap/snapcraft.yaml"
       ],
       "matchStrings": [
         "https://github\\.com/canonical/inference-snaps-webui/releases/download/(?<currentValue>v[^/]+)/inference-snaps-webui"
@@ -33,8 +33,8 @@
     {
       "customType": "regex",
       "description": "Update llama.cpp builds",
-      "fileMatch": [
-        "^snap/snapcraft\\.yaml$"
+      "managerFilePatterns": [
+        "snap/snapcraft.yaml"
       ],
       "matchStrings": [
         "https://github\\.com/canonical/llama\\.cpp-builds/releases/download/(?<currentValue>[^/]+)/llamacpp",
@@ -47,8 +47,8 @@
     {
       "customType": "regex",
       "description": "Update openvino-model-server",
-      "fileMatch": [
-        "^snap/snapcraft\\.yaml$"
+      "managerFilePatterns": [
+        "snap/snapcraft.yaml"
       ],
       "matchStrings": [
         "https://github\\.com/openvinotoolkit/model_server/releases/download/(?<currentValue>v[^/]+)/ovms"

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,19 @@
     },
     {
       "customType": "regex",
+      "description": "Update inference-snaps-webui",
+      "fileMatch": [
+        "^snap/snapcraft\\.yaml$"
+      ],
+      "matchStrings": [
+        "https://github\\.com/canonical/inference-snaps-webui/releases/download/(?<currentValue>v[^/]+)/inference-snaps-webui"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "canonical/inference-snaps-webui",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "description": "Update llama.cpp builds",
       "fileMatch": [
         "^snap/snapcraft\\.yaml$"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
   llamacpp:
     plugin: dump
     source:
-      - on amd64: https://github.com/jpm-canonical/llama.cpp-builds/releases/download/b8589/llamacpp-amd64.tar.gz
-      - on arm64: https://github.com/jpm-canonical/llama.cpp-builds/releases/download/b8589/llamacpp-arm64.tar.gz
+      - on amd64: https://github.com/canonical/llama.cpp-builds/releases/download/b8589/llamacpp-amd64.tar.gz
+      - on arm64: https://github.com/canonical/llama.cpp-builds/releases/download/b8589/llamacpp-arm64.tar.gz
     stage-packages:
       - libgomp1
     organize:
@@ -199,8 +199,8 @@ parts:
   llamacpp-cuda:
     plugin: dump
     source:
-      - on amd64: https://github.com/jpm-canonical/llama.cpp-builds/releases/download/b8589/llamacpp-amd64+cuda12.tar.gz
-      - on arm64: https://github.com/jpm-canonical/llama.cpp-builds/releases/download/b8589/llamacpp-arm64+cuda12.tar.gz
+      - on amd64: https://github.com/canonical/llama.cpp-builds/releases/download/b8589/llamacpp-amd64+cuda12.tar.gz
+      - on arm64: https://github.com/canonical/llama.cpp-builds/releases/download/b8589/llamacpp-arm64+cuda12.tar.gz
     stage-packages:
       - libgomp1
     organize:
@@ -209,9 +209,8 @@ parts:
   
   llamacpp-rocm:
     plugin: dump
-    # Detailed instructions on how to create llama.cpp with rocm support release archive: https://github.com/jpm-canonical/llama.cpp-builds/releases/tag/b8287
     source:
-      - on amd64: https://github.com/jpm-canonical/llama.cpp-builds/releases/download/b8589/llamacpp-amd64+rocm.tar.gz
+      - on amd64: https://github.com/canonical/llama.cpp-builds/releases/download/b8589/llamacpp-amd64+rocm.tar.gz
       - on arm64: components/llamacpp-rocm
     stage-packages:
       - on amd64:


### PR DESCRIPTION
- Update source source URLs for llama.cpp builds
- Add Renovate custom manager for webui
- Migrate renovate config to use [managerFilePatterns](https://docs.renovatebot.com/configuration-options/#managerfilepatterns). The fileMatch field (regex only) has been deprecated.