### PR TITLE
Pass server arguments to runtime

### DIFF
--- a/engines/amd-gpu/server
+++ b/engines/amd-gpu/server
@@ -1,5 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 sleep_idle_seconds="$(modelctl get sleep-idle-seconds)"
 
-exec "$SNAP_COMPONENTS/llamacpp-rocm/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds"
+exec "$SNAP_COMPONENTS/llamacpp-rocm/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds" "$@"

--- a/engines/cpu-xsmall/server
+++ b/engines/cpu-xsmall/server
@@ -1,5 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 sleep_idle_seconds="$(modelctl get sleep-idle-seconds)"
 
-exec "$SNAP_COMPONENTS/llamacpp/server" --sleep-idle-seconds "$sleep_idle_seconds"
+exec "$SNAP_COMPONENTS/llamacpp/server" --sleep-idle-seconds "$sleep_idle_seconds" "$@"

--- a/engines/cpu/server
+++ b/engines/cpu/server
@@ -1,6 +1,6 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 sleep_idle_seconds="$(modelctl get sleep-idle-seconds)"
 
-exec "$SNAP_COMPONENTS/llamacpp/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds"
+exec "$SNAP_COMPONENTS/llamacpp/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds" "$@"
 

--- a/engines/intel-cpu/server
+++ b/engines/intel-cpu/server
@@ -1,3 +1,3 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
-exec "$SNAP_COMPONENTS/openvino-model-server/server" --target_device CPU
+exec "$SNAP_COMPONENTS/openvino-model-server/server" --target_device CPU "$@"

--- a/engines/intel-gpu/server
+++ b/engines/intel-gpu/server
@@ -1,3 +1,3 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
-exec "$SNAP_COMPONENTS/openvino-model-server/server" --target_device GPU
+exec "$SNAP_COMPONENTS/openvino-model-server/server" --target_device GPU "$@"

--- a/engines/nvidia-gpu-amd64/server
+++ b/engines/nvidia-gpu-amd64/server
@@ -1,5 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 sleep_idle_seconds="$(modelctl get sleep-idle-seconds)"
 
-exec "$SNAP_COMPONENTS/llamacpp-cuda/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds"
+exec "$SNAP_COMPONENTS/llamacpp-cuda/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds" "$@"

--- a/engines/nvidia-gpu-arm64/server
+++ b/engines/nvidia-gpu-arm64/server
@@ -1,5 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 sleep_idle_seconds="$(modelctl get sleep-idle-seconds)"
 
-exec "$SNAP_COMPONENTS/llamacpp-cuda/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds"
+exec "$SNAP_COMPONENTS/llamacpp-cuda/server" --mmproj "$MMPROJ_FILE" --sleep-idle-seconds "$sleep_idle_seconds" "$@"

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -7,4 +7,4 @@ set -euo pipefail
 $SNAP/bin/export-shared-configs.sh
 
 engine="$(modelctl status --wait-for-components --format=json | jq -r .engine)"
-exec modelctl run "$SNAP/engines/$engine/server" --wait-for-components
+exec modelctl run --wait-for-components -- "$SNAP/engines/$engine/server" "$@"


### PR DESCRIPTION
Limit xtracing to the command that executes the runtime server.

Pass arguments from app to runtime server, enabled by https://github.com/canonical/inference-snaps-cli/pull/332 

```console
$ sudo snap run gemma3.server -h
+ exec llama-server --model /snap/gemma3/components/x7/model-270m-it-q4-0-gguf/gemma-3-270m-it-Q4_0.gguf --port 8328 --host 127.0.0.1 --no-warmup --sleep-idle-seconds 600 -h
load_backend: loaded CPU backend from /snap/gemma3/components/mnt/llamacpp/x7/bin/libggml-cpu-alderlake.so
----- common params -----

-h,    --help, --usage                  print usage and exit
...
```