### PR TITLE
Update workflow to include permissions for label removal

### DIFF
--- a/.github/workflows/build-and-test-pr.yaml
+++ b/.github/workflows/build-and-test-pr.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ labeled ]
 
+
+permissions:
+  contents: read
+  pull-requests: write # required for removing labels
+
 jobs:
   remove-build-label:
     uses: canonical/inference-snaps-dev/.github/workflows/remove-label.yaml@v2


### PR DESCRIPTION
Add PR write permissions to the workflow for label removal. The label removal used to work with the default permissions, but this has changed, either due to stricter organization or Github permissions.

Replicates https://github.com/canonical/gemma4-snap/pull/30