### PR TITLE
feat: consume model capabilities dynamically

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: canonical/inference-snaps-cli
           path: inference-snaps-cli
-          ref: v2.0.0-beta.5
+          ref: v2.0.0-beta.8
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/scripts/server-webui.sh
+++ b/scripts/server-webui.sh
@@ -4,14 +4,4 @@ set -euo pipefail
 port="$(modelctl get webui.http.port)"
 host="$(modelctl get webui.http.host)"
 
-model_name="$(modelctl show-model --format=json | jq -r .name)"
-
-# The capabilities depend on the model
-# gemma3 270m and 1b are text-only.
-if [[ "$model_name" == 270m* || "$model_name" == 1b* ]]; then
-    capabilities="text, text:markdown"
-else 
-    capabilities="text, text:markdown, vision"
-fi
-
-exec modelctl serve-webui "$SNAP/webui" --port "$port" --host "$host" --capabilities "$capabilities"
+exec modelctl serve-webui "$SNAP/webui" --port "$port" --host "$host"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,8 +142,8 @@ parts:
 
   cli:
     source:
-      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.5/inference-snaps-cli-linux-amd64.tar.xz
-      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.5/inference-snaps-cli-linux-arm64.tar.xz
+      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.8/inference-snaps-cli-linux-amd64.tar.xz
+      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.8/inference-snaps-cli-linux-arm64.tar.xz
     plugin: dump
     override-build: |
 
@@ -200,7 +200,7 @@ parts:
 
   webui:
     plugin: dump
-    source: https://github.com/canonical/inference-snaps-webui/releases/download/v1.0.0/inference-snaps-webui.tar.xz
+    source: https://github.com/canonical/inference-snaps-webui/releases/download/v1.1.0/inference-snaps-webui.tar.xz
     organize:
       "*": webui/
 


### PR DESCRIPTION
## What
Removes the hardcoded WebUI capability flags in favor of dynamic detection, and updates the toolchain to versions that support this.

This replicates peer-reviewed changes from https://github.com/canonical/smollm2-snap/pull/11.

## Changes
- Bump `inference-snaps-cli` to `v2.0.0-beta.8` (workflow + snapcraft.yaml)
- Bump `inference-snaps-webui` to `v1.1.0` (snapcraft.yaml)
- Remove hardcoded `capabilities` variable and `--capabilities` flag from `scripts/server-webui.sh`; the WebUI now derives capabilities from the model itself.

## Testing
- CI build/tests via updated workflow
