### PR TITLE
Update dependency canonical/inference-snaps-cli to v2.0.0-beta.9 and refactor model IDs

### DIFF
--- a/engines/amd-gpu/engine.yaml
+++ b/engines/amd-gpu/engine.yaml
@@ -74,10 +74,10 @@ devices:
 runtime: llamacpp-rocm
 
 model:
-  default: 4b-it-q4-0-gguf
+  default: gemma3-4b
   options:
-    - 270m-it-q4-0-gguf
-    - 4b-it-q4-0-gguf
+    - gemma3-270m
+    - gemma3-4b
 
 configurations:
   sleep-idle-seconds: 600

--- a/engines/cpu/engine.yaml
+++ b/engines/cpu/engine.yaml
@@ -16,10 +16,10 @@ devices:
 runtime: llamacpp
 
 model:
-  default: 4b-it-q4-0-gguf
+  default: gemma3-4b
   options:
-    - 270m-it-q4-0-gguf
-    - 4b-it-q4-0-gguf
+    - gemma3-270m
+    - gemma3-4b
 
 configurations:
   sleep-idle-seconds: 600

--- a/engines/intel-cpu/engine.yaml
+++ b/engines/intel-cpu/engine.yaml
@@ -14,6 +14,6 @@ devices:
 runtime: openvino-model-server
 
 model:
-  default: 4b-it-int4-fq-ov
+  default: gemma3-4b-ov
   options:
-    - 4b-it-int4-fq-ov
+    - gemma3-4b-ov

--- a/engines/intel-gpu/engine.yaml
+++ b/engines/intel-gpu/engine.yaml
@@ -368,6 +368,6 @@ devices:
 runtime: openvino-model-server
 
 model:
-  default: 4b-it-int4-fq-ov
+  default: gemma3-4b-ov
   options:
-    - 4b-it-int4-fq-ov
+    - gemma3-4b-ov

--- a/engines/nvidia-gpu/engine.yaml
+++ b/engines/nvidia-gpu/engine.yaml
@@ -20,10 +20,10 @@ devices:
 runtime: llamacpp-cuda
 
 model:
-  default: 4b-it-q4-0-gguf
+  default: gemma3-4b
   options:
-    - 270m-it-q4-0-gguf
-    - 4b-it-q4-0-gguf
+    - gemma3-270m
+    - gemma3-4b
 
 configurations:
   sleep-idle-seconds: 600

--- a/models/gemma3-270m/model.yaml
+++ b/models/gemma3-270m/model.yaml
@@ -1,9 +1,8 @@
-id: 270m-it-q4-0-gguf
-name: 270m
+name: gemma3-270m
 
 description: Gemma 3 270M, a text-only instruction-tuned model
 model-card-url: https://huggingface.co/google/gemma-3-270m-it
-quantization: Q4_0
+quantization: it-q4-0
 
 disk-size: 200M
 

--- a/models/gemma3-4b-ov/model.yaml
+++ b/models/gemma3-4b-ov/model.yaml
@@ -1,9 +1,9 @@
-id: 4b-it-int4-fq-ov
-name: 4b
+name: gemma3-4b-ov
+alias: gemma3-4b
 
 description: Gemma 3 4B, a multimodal (text + vision) instruction-tuned model, optimized for OpenVINO
 model-card-url: https://huggingface.co/google/gemma-3-4b-it
-quantization: INT4
+quantization: it-int4-fq
 
 disk-size: 2700M
 

--- a/models/gemma3-4b/model.yaml
+++ b/models/gemma3-4b/model.yaml
@@ -1,9 +1,8 @@
-id: 4b-it-q4-0-gguf
-name: 4b
+name: gemma3-4b
 
 description: Gemma 3 4B, a multimodal (text + vision) instruction-tuned model
 model-card-url: https://huggingface.co/google/gemma-3-4b-it
-quantization: Q4_0
+quantization: it-q4-0
 
 disk-size: 2800M
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,8 +142,8 @@ parts:
 
   cli:
     source:
-      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.8/inference-snaps-cli-linux-amd64.tar.xz
-      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.8/inference-snaps-cli-linux-arm64.tar.xz
+      - on amd64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.9/inference-snaps-cli-linux-amd64.tar.xz
+      - on arm64: https://github.com/canonical/inference-snaps-cli/releases/download/v2.0.0-beta.9/inference-snaps-cli-linux-arm64.tar.xz
     plugin: dump
     override-build: |
 


### PR DESCRIPTION
Updates the inference-snaps-cli dependency from v2.0.0-beta.8 to v2.0.0-beta.9 and refactors the model identifiers to match the new CLI schema (the `id` field was removed, `name` is now the primary key and must match the model's directory name).
## Model ID refactor
| Old directory / id | New `name` | `alias` | `quantization` |
|--------------------|-----------|---------|----------------|
| `270m-it-q4-0-gguf` | `gemma3-270m` | — | `it-q4-0` |
| `4b-it-q4-0-gguf` | `gemma3-4b` | — | `it-q4-0` |
| `4b-it-int4-fq-ov` | `gemma3-4b-ov` | `gemma3-4b` | `it-int4-fq` |
- Names use the `gemma3-` snap prefix plus the parameter count; llama.cpp/GGUF variants keep the short names.
- The OpenVINO 4B variant gets the `-ov` suffix and aliases back to `gemma3-4b` so the same friendly name works across engines.
- Descriptors previously encoded in the model name (the `it` instruction-tuned designation, the `fq` qualifier and the quantization) are preserved in the `quantization` field.
- Model directories renamed to match the new names; all engine.yaml `model.default` / `model.options` references updated.