### PR TITLE
Revert model quantization field changes from beta.9 refactor

### DIFF
--- a/models/gemma3-270m/model.yaml
+++ b/models/gemma3-270m/model.yaml
@@ -2,7 +2,7 @@ name: gemma3-270m
 
 description: Gemma 3 270M, a text-only instruction-tuned model
 model-card-url: https://huggingface.co/google/gemma-3-270m-it
-quantization: it-q4-0
+quantization: Q4_0
 
 disk-size: 200M
 

--- a/models/gemma3-4b-ov/model.yaml
+++ b/models/gemma3-4b-ov/model.yaml
@@ -3,7 +3,7 @@ alias: gemma3-4b
 
 description: Gemma 3 4B, a multimodal (text + vision) instruction-tuned model, optimized for OpenVINO
 model-card-url: https://huggingface.co/google/gemma-3-4b-it
-quantization: it-int4-fq
+quantization: int4-fq
 
 disk-size: 2700M
 

--- a/models/gemma3-4b-ov/model.yaml
+++ b/models/gemma3-4b-ov/model.yaml
@@ -3,7 +3,7 @@ alias: gemma3-4b
 
 description: Gemma 3 4B, a multimodal (text + vision) instruction-tuned model, optimized for OpenVINO
 model-card-url: https://huggingface.co/google/gemma-3-4b-it
-quantization: int4-fq
+quantization: INT4
 
 disk-size: 2700M
 

--- a/models/gemma3-4b/model.yaml
+++ b/models/gemma3-4b/model.yaml
@@ -2,7 +2,7 @@ name: gemma3-4b
 
 description: Gemma 3 4B, a multimodal (text + vision) instruction-tuned model
 model-card-url: https://huggingface.co/google/gemma-3-4b-it
-quantization: it-q4-0
+quantization: q4_0
 
 disk-size: 2800M
 

--- a/models/gemma3-4b/model.yaml
+++ b/models/gemma3-4b/model.yaml
@@ -2,7 +2,7 @@ name: gemma3-4b
 
 description: Gemma 3 4B, a multimodal (text + vision) instruction-tuned model
 model-card-url: https://huggingface.co/google/gemma-3-4b-it
-quantization: q4_0
+quantization: Q4_0
 
 disk-size: 2800M
 


### PR DESCRIPTION
This PR reverts changes made to the model `quantization` fields in `model.yaml` files, which were introduced by [Update dependency canonical/inference-snaps-cli to v2.0.0-beta.9 and refactor model IDs](https://github.com/canonical/gemma3-snap/pull/146).