### PR TITLE
fix: extract OpenAI URL from status entrypoint

### DIFF
--- a/scripts/export-shared-configs.sh
+++ b/scripts/export-shared-configs.sh
@@ -8,7 +8,7 @@ echo "$status_json" > "$STATUS_SHARE/status.json"
 
 # OpenAI endpoint configuration in Open WebUI content sharing format
 rm -f "$OWUI_SHARE/openai.json"
-openai_url=$(echo "$status_json" | jq -r '.endpoints.openai // empty')
+openai_url=$(echo "$status_json" | jq -r '.entrypoints.openai.url // empty')
 if [ -n "$openai_url" ]; then
   mkdir -p "$OWUI_SHARE"
   jq -n \


### PR DESCRIPTION
modelctl beta.12 changed the `status --format=json` output schema, breaking the OpenAI base URL extraction in `export-shared-configs.sh`.

## Change

Updated the `jq` path to match the new schema (same fix as canonical/gemma4-snap#108):

```diff
-openai_url=$(echo "$status_json" | jq -r '.endpoints.openai // empty')
+openai_url=$(echo "$status_json" | jq -r '.entrypoints.openai.url // empty')
```